### PR TITLE
Correct bioformat error #28

### DIFF
--- a/tools/fiji_utils/bioimageit_convert.ijm
+++ b/tools/fiji_utils/bioimageit_convert.ijm
@@ -104,8 +104,10 @@ function is_file_in_filter(filename, filter)
 function import_image(original_file_path, destination_dir, data_name, author, date, tags)
 {
 	// open the image with BioFormat 
-	open(original_file_path);
-	//run("Bio-Formats Importer", "open=["+original_file_path+"] color_mode=Default display_metadata rois_import=[ROI manager] view=Hyperstack stack_order=XYCZT use_virtual_stack");
+	// Do not use `open(…)` built-in function as it would try to open import pop-up in headless mode, and fail. 
+	run("Bio-Formats Macro Extensions");
+	Ext.openImagePlus(original_file_path);
+
 	rename("input_image");
 	metadata_json = get_metadata_to_json();
 


### PR DESCRIPTION
Fixes bioimageit/bioimageit#28

Use `Bio-Formats Macro Extensions` to open bioformat files instead of the built in function.
By default the macro tried to open an import pop-up making that would make the macro failed in headless mode.